### PR TITLE
Lookup python in $PATH

### DIFF
--- a/FritzingCheckPart.py
+++ b/FritzingCheckPart.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # A Fritzing part check script. This will read various types of Fritzing files
 # (.fzp and .svg) and both check them for correctness and converting xml

--- a/FritzingTools.py
+++ b/FritzingTools.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Various support routines for processing Fritzing's fzp and svg files. 
 

--- a/PP.py
+++ b/PP.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # A python xml pretty_print script written to pretty print svg files from 
 # Inkscape, but should work on pretty much any xml. 

--- a/PPTools.py
+++ b/PPTools.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # The support routines for pretty printing Fritzing svg files (and possibly
 # other xml as well.)


### PR DESCRIPTION
OS X has different python location so `env` utility will find appropriate. Also I included executable flag right into git repo. I also installed lxml using `pip3 install xmlx` and then script worked fine for me.

A little bit offtopic, but I would recommend instead of making backup copies and correct files in place, put corrected files to output and leave input intact. 